### PR TITLE
allow trailing zero in extract while using strict mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,16 @@ dist: trusty
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
     - 7
     - hhvm
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
 
 before_script:
     - composer self-update

--- a/src/Rize/UriTemplate.php
+++ b/src/Rize/UriTemplate.php
@@ -68,7 +68,7 @@ class UriTemplate
         foreach($nodes as $node) {
 
             // if strict is given, and there's no remaining uri just return null
-            if ($strict && !$uri) {
+            if ($strict && !strlen($uri)) {
                 return null;
             }
 
@@ -79,7 +79,7 @@ class UriTemplate
         }
 
         // if there's remaining $uri, matching is failed
-        if ($strict && (bool)$uri) {
+        if ($strict && strlen($uri)) {
             return null;
         }
 

--- a/test/Rize/UriTemplateTest.php
+++ b/test/Rize/UriTemplateTest.php
@@ -1,7 +1,6 @@
 <?php
 error_reporting(-1);
 use Rize\UriTemplate\UriTemplate;
-use Rize\UriTemplate\Node;
 
 /**
  * URI Template
@@ -352,7 +351,7 @@ class UriTemplateTest extends \PHPUnit_Framework_TestCase
     public function dataExtraction()
     {
         return array(
-           array(
+            array(
                 '/no/{term:1}/random/foo{?query,list%,keys%}',
                 '/no/j/random/foo?query=1,2,3&list%5B%5D=a&list%5B%5D=b&keys%5Ba%5D=1&keys%5Bb%5D=2&keys%5Bc%5D%5Btest%5D%5Btest%5D=1',
                 array(
@@ -416,6 +415,13 @@ class UriTemplateTest extends \PHPUnit_Framework_TestCase
                     'lang'   => array('th', 'jp', 'en'),
                     'term'   => 'john',
                     'term:1' => 'j',
+                ),
+            ),
+            array(
+                '/foo/bar/{number}',
+                '/foo/bar/0',
+                array(
+                    'number' => 0,
                 ),
             ),
         );
@@ -528,6 +534,13 @@ class UriTemplateTest extends \PHPUnit_Framework_TestCase
                         'Hello World!',
                         '3',
                     ),
+                ),
+            ),
+            array(
+                '/foo/bar/{number}',
+                '/foo/bar/0',
+                array(
+                    'number' => 0,
                 ),
             ),
             array(


### PR DESCRIPTION
If we are in strict mode we can't have a trailing parameter with the value of _0_ using the extract method. This is because of [PHP string 0 == false](https://3v4l.org/qQkXC), which happens in the matching part. For this I added a testcase where you can see what I mean. I fixed it by using strlen instead of the plain 'is not' check.

I think having a trailing zero param is not too common, I just ran in there while testing stuff, but it could be a feature blocker.