### PR TITLE
fix: ignore test directory when exporting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/test  export-ignore


### PR DESCRIPTION
This ignores the `test/` directory when creating exports on Packagist. Currently the tests are included when requiring the package via Composer.