### PR TITLE
tests: fix depends PHPDoc tag

### DIFF
--- a/test/Rize/Uri/Node/ParserTest.php
+++ b/test/Rize/Uri/Node/ParserTest.php
@@ -108,7 +108,7 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @ depends testParseTemplateWithLiteral
+     * @depends testParseTemplateWithLiteral
      */
     public function testParseTemplateWithTwoVariablesAndDotBetweenStrict()
     {
@@ -119,7 +119,7 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @ depends testParseTemplateWithLiteral
+     * @depends testParseTemplateWithLiteral
      */
     public function testParseTemplateWithThreeVariablesAndDotBetweenStrict()
     {


### PR DESCRIPTION
As the `test/` directory is exported when creating releases, this causes issues if parsing the contents of the package (see https://github.com/laravel-zero/laravel-zero/issues/334).

See https://github.com/rize/UriTemplate/pull/17 for the corresponding change to stop the tests being published as part of the Composer package.