### PR TITLE
fix: extraction with optional query

### DIFF
--- a/src/Rize/UriTemplate/Node/Expression.php
+++ b/src/Rize/UriTemplate/Node/Expression.php
@@ -104,7 +104,7 @@ class Expression extends Abstraction
         $op = $this->operator;
 
         // check expression operator first
-        if ($op->id && $uri[0] !== $op->id) {
+        if ($op->id && isset($uri[0]) && $uri[0] !== $op->id) {
           return array($uri, $params);
         }
 

--- a/test/Rize/UriTemplateTest.php
+++ b/test/Rize/UriTemplateTest.php
@@ -425,6 +425,14 @@ class UriTemplateTest extends TestCase
                     'number' => 0,
                 ),
             ),
+            array(
+                '/some/{path}{?ref}',
+                '/some/foo',
+                array(
+                    'path' => 'foo',
+                    'ref' => null,
+                ),
+            ),
         );
     }
 


### PR DESCRIPTION
```php
$template->extract('/some/{path}{?ref}', '/some/foo'); // throws Uninitialized string offset: 0

$template->extract('/some/{path}{?ref}', '/some/foo?ref=bar'); // works as expected
```