### PR TITLE
Modify export-ignore entries in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,7 @@
-/test  export-ignore
+/tests export-ignore
 .github export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+/phpunit.xml export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/phpstan.neon export-ignore


### PR DESCRIPTION
Current archive targets other than src/ will be as follows:
```bash
gh api repos/rize/UriTemplate/tarball/HEAD | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^src/' | sort
```

```
composer.json
LICENSE
.php-cs-fixer.dist.php
phpstan.neon
phpunit.xml
README.md
tests/
tests/fixtures/
tests/fixtures/extended-tests.json
tests/fixtures/json2xml.xslt
tests/fixtures/negative-tests.json
tests/fixtures/README.md
tests/fixtures/spec-examples-by-section.json
tests/fixtures/spec-examples.json
tests/fixtures/transform-json-tests.xslt
tests/Rize/
tests/Rize/Uri/
tests/Rize/Uri/Node/
tests/Rize/Uri/Node/ParserTest.php
tests/Rize/UriTemplateTest.php
```

With this PR, the archive targets other than src/ will be as follows:
```bash
gh api repos/sasezaki/UriTemplate/tarball/patch-gitattributes | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^src/' | sort
```

```
composer.json
LICENSE
README.md
```

Changes:
- Fixed `/test export-ignore` → `/tests export-ignore` (typo — tests directory was not being excluded)
- Added `/phpunit.xml export-ignore`
- Added `/.php-cs-fixer.dist.php export-ignore`
- Added `/phpstan.neon export-ignore`
