### PR TITLE
Fix prefix modifier multibyte truncation and pct-encoded triplet handling (RFC 6570)

### DIFF
--- a/src/Rize/UriTemplate/Node/Literal.php
+++ b/src/Rize/UriTemplate/Node/Literal.php
@@ -2,4 +2,32 @@
 
 namespace Rize\UriTemplate\Node;
 
-class Literal extends Abstraction {}
+use Rize\UriTemplate\Parser;
+
+class Literal extends Abstraction
+{
+    /**
+     * Non-ASCII literal text must be pct-encoded on expansion (RFC 6570 #3.1).
+     */
+    public function expand(Parser $parser, array $params = []): ?string
+    {
+        return self::encodeNonAscii($this->getToken());
+    }
+
+    public function match(Parser $parser, string $uri, array $params = [], bool $strict = false): ?array
+    {
+        // also accept the encoded form that `expand` produces
+        $encoded = self::encodeNonAscii($this->getToken());
+
+        if ($encoded !== $this->getToken() && str_starts_with($uri, $encoded)) {
+            return [substr($uri, strlen($encoded)), $params];
+        }
+
+        return parent::match($parser, $uri, $params, $strict);
+    }
+
+    private static function encodeNonAscii(string $value): string
+    {
+        return preg_replace_callback('#[\x80-\xFF]+#', static fn($m) => rawurlencode($m[0]), $value);
+    }
+}

--- a/src/Rize/UriTemplate/Operator/Abstraction.php
+++ b/src/Rize/UriTemplate/Operator/Abstraction.php
@@ -214,7 +214,7 @@ abstract class Abstraction
         $result  = null;
 
         if ($options['modifier'] === ':') {
-            $val = substr($val, 0, (int) $options['value']);
+            $val = mb_substr($val, 0, (int) $options['value']);
         }
 
         return $result . $this->encode($parser, $var, $val);
@@ -264,29 +264,41 @@ abstract class Abstraction
         }
 
         array_walk($values, function (&$v, $k) use ($assoc_sep, $reserved, $list, $maps): void {
-            $encoded = rawurlencode($v);
+            // reserved operators pass pct-encoded triplets through unchanged
+            $encoded = $reserved
+                ? static::pctEncode((string) $v, $maps)
+                : rawurlencode((string) $v);
 
             // assoc? encode key too
             if (!$list) {
-                $encoded = rawurlencode($k) . $assoc_sep . $encoded;
+                $key     = $reserved ? static::pctEncode((string) $k, $maps) : rawurlencode((string) $k);
+                $encoded = $key . $assoc_sep . $encoded;
             }
 
-            // rawurlencode is compliant with 'unreserved' set
-            if (!$reserved) {
-                $v = $encoded;
-            }
-
-            // decode chars in reserved set
-            else {
-                $v = str_replace(
-                    array_keys($maps),
-                    $maps,
-                    $encoded,
-                );
-            }
+            $v = $encoded;
         });
 
         return implode($sep, $values);
+    }
+
+    /**
+     * Pct-encodes a string but keeps valid pct-encoded triplets intact.
+     * `$maps` restores reserved chars from their encoded form.
+     */
+    public static function pctEncode(string $value, array $maps = []): string
+    {
+        $result = '';
+        foreach (preg_split('#(%[0-9A-Fa-f]{2})#', $value, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY) as $part) {
+            if (preg_match('#\A%[0-9A-Fa-f]{2}\z#', $part)) {
+                $result .= $part;
+                continue;
+            }
+
+            $encoded = rawurlencode($part);
+            $result .= $maps ? str_replace(array_keys($maps), $maps, $encoded) : $encoded;
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Rize/UriTemplate/Operator/Named.php
+++ b/src/Rize/UriTemplate/Operator/Named.php
@@ -56,7 +56,7 @@ class Named extends Abstraction
     {
         $val     = (string) $val;
         $options = $var->options;
-        $result  = $this->encode($parser, $var, $var->name);
+        $result  = static::pctEncode($var->name);
 
         // handle empty value
         if ($val === '') {
@@ -78,7 +78,7 @@ class Named extends Abstraction
             return null;
         }
 
-        $result = $this->encode($parser, $var, $var->name);
+        $result = static::pctEncode($var->name);
 
         $result .= '=';
 
@@ -195,6 +195,13 @@ class Named extends Abstraction
                 static::$reserved_chars,
                 $query,
             );
+        }
+
+        // keep pct-encoded triplets in the variable name intact
+        $name = rawurlencode($var->name);
+        if ($name !== ($pct_name = static::pctEncode($var->name))) {
+            $needles = $var->options['modifier'] === '%' ? [$name . '=', $name . '%5B'] : [$name . '='];
+            $query   = str_replace($needles, str_replace($name, $pct_name, $needles), $query);
         }
 
         return $query;

--- a/tests/Rize/UriTemplateTest.php
+++ b/tests/Rize/UriTemplateTest.php
@@ -184,6 +184,91 @@ class UriTemplateTest extends TestCase
         }
     }
 
+    public static function dataPrefixModifierMultibyte()
+    {
+        $params = ['greek' => 'αβγδε', 'clef' => '𝄞stave'];
+
+        # RFC 6570 s2.4.1: max-length counts characters, not octets
+        return [
+            ['%CE%B1%CE%B2', '{greek:2}', $params],
+            ['%CE%B1%CE%B2', '{+greek:2}', $params],
+            ['#%CE%B1%CE%B2', '{#greek:2}', $params],
+            ['.%CE%B1%CE%B2', '{.greek:2}', $params],
+            ['/%CE%B1%CE%B2', '{/greek:2}', $params],
+            [';greek=%CE%B1%CE%B2', '{;greek:2}', $params],
+            ['?greek=%CE%B1%CE%B2', '{?greek:2}', $params],
+            ['&greek=%CE%B1%CE%B2', '{&greek:2}', $params],
+            ['%F0%9D%84%9Es', '{clef:2}', $params],
+        ];
+    }
+
+    #[DataProvider('dataPrefixModifierMultibyte')]
+    public function testPrefixModifierMultibyte(string $expected, string $template, array $params)
+    {
+        $this->assertSame($expected, $this->service()->expand($template, $params));
+    }
+
+    public static function dataReservedPctTriplets()
+    {
+        $params = [
+            'id'      => 'admin%2F',
+            'not_pct' => '%foo',
+            'list'    => ['red%25', '%2Fgreen'],
+            'keys'    => ['key%2F' => 'val%2F'],
+        ];
+
+        # RFC 6570 s3.2.3: pct-encoded triplets pass through reserved/fragment expansion
+        return [
+            ['admin%2F', '{+id}', $params],
+            ['#admin%2F', '{#id}', $params],
+            ['red%25,%2Fgreen', '{+list}', $params],
+            ['#red%25,%2Fgreen', '{#list}', $params],
+            ['key%2F,val%2F', '{+keys}', $params],
+            # a prefix cut mid-triplet leaves no triplet to preserve
+            ['admin%25', '{+id:6}', $params],
+            # a bare '%' is not a triplet and must still be encoded
+            ['%25foo', '{+not_pct}', $params],
+            # simple expansion still encodes '%' itself
+            ['admin%252F', '{id}', $params],
+            ['key%252F,val%252F', '{keys}', $params],
+        ];
+    }
+
+    #[DataProvider('dataReservedPctTriplets')]
+    public function testReservedPctTriplets(string $expected, string $template, array $params)
+    {
+        $this->assertSame($expected, $this->service()->expand($template, $params));
+    }
+
+    public static function dataPctEncodedVarname()
+    {
+        # RFC 6570 s2.3: varname may contain pct-encoded triplets; they are emitted as-is
+        return [
+            ['?Stra%C3%9Fe=Gr%C3%BCner%20Weg', '{?Stra%C3%9Fe}', ['Stra%C3%9Fe' => 'Grüner Weg']],
+            [';Stra%C3%9Fe=x', '{;Stra%C3%9Fe}', ['Stra%C3%9Fe' => 'x']],
+            ['?Stra%C3%9Fe=a&Stra%C3%9Fe=b', '{?Stra%C3%9Fe*}', ['Stra%C3%9Fe' => ['a', 'b']]],
+            ['?Stra%C3%9Fe=a,b', '{?Stra%C3%9Fe}', ['Stra%C3%9Fe' => ['a', 'b']]],
+        ];
+    }
+
+    #[DataProvider('dataPctEncodedVarname')]
+    public function testPctEncodedVarname(string $expected, string $template, array $params)
+    {
+        $this->assertSame($expected, $this->service()->expand($template, $params));
+    }
+
+    public function testLiteralNonAsciiEncoding()
+    {
+        $service = $this->service();
+
+        # RFC 6570 s3.1: non-ASCII literal text is pct-encoded on expansion
+        $this->assertSame('caf%C3%A9/value', $service->expand('café/{var}', ['var' => 'value']));
+
+        # extraction accepts the encoded form that expand produces
+        $this->assertSame(['var' => 'value'], $service->extract('café/{var}', 'caf%C3%A9/value'));
+        $this->assertSame(['var' => 'value'], $service->extract('café/{var}', 'café/value'));
+    }
+
     public static function dataExtractStrictMode()
     {
         $dataTest = [['/search/{term:1}/{term}/{?q*,limit}', '/search/j/john/?a=1&b=2&limit=10', ['term:1' => 'j', 'term' => 'john', 'limit' => '10', 'q' => ['a' => '1', 'b' => '2']]], ['http://example.com/{term:1}/{term}/search{?q*,lang}', 'http://example.com/j/john/search?q=Hello%20World%21&q=3&lang=th,jp,en', ['term:1' => 'j', 'term' => 'john', 'lang' => ['th', 'jp', 'en'], 'q' => ['Hello World!', '3']]], ['/foo/bar/{number}', '/foo/bar/0', ['number' => 0]], ['/', '/', []]];

--- a/tests/fixtures/extended-tests.json
+++ b/tests/fixtures/extended-tests.json
@@ -11,7 +11,7 @@
             "lang"         : "en",
             "geocode"      : ["37.76","-122.427"],
             "first_name"   : "John",
-            "last.name"    : "Doe", 
+            "last.name"    : "Doe",
             "Some%20Thing" : "foo",
             "number"       : 6,
             "long"         : 37.76,
@@ -28,18 +28,8 @@
         "testcases":[
 
             [ "{/id*}" , "/person" ],
-            [ "{/id*}{?fields,first_name,last.name,token}" , [ 
-            	"/person?fields=id,name,picture&first_name=John&last.name=Doe&token=12345",
-            	"/person?fields=id,picture,name&first_name=John&last.name=Doe&token=12345",
-            	"/person?fields=picture,name,id&first_name=John&last.name=Doe&token=12345",
-            	"/person?fields=picture,id,name&first_name=John&last.name=Doe&token=12345",
-            	"/person?fields=name,picture,id&first_name=John&last.name=Doe&token=12345",
-            	"/person?fields=name,id,picture&first_name=John&last.name=Doe&token=12345"]
-            	],
-            ["/search.{format}{?q,geocode,lang,locale,page,result_type}",
-            	[ "/search.json?q=URI%20Templates&geocode=37.76,-122.427&lang=en&page=5",
-            	  "/search.json?q=URI%20Templates&geocode=-122.427,37.76&lang=en&page=5"]
-                ],
+            [ "{/id*}{?fields,first_name,last.name,token}","/person?fields=id,name,picture&first_name=John&last.name=Doe&token=12345"],
+            ["/search.{format}{?q,geocode,lang,locale,page,result_type}","/search.json?q=URI%20Templates&geocode=37.76,-122.427&lang=en&page=5"],
             ["/test{/Some%20Thing}", "/test/foo" ],
             ["/set{?number}", "/set?number=6"],
             ["/loc{?long,lat}" , "/loc?long=37.76&lat=-122.427"],
@@ -47,7 +37,7 @@
             ["/sparql{?query}", "/sparql?query=PREFIX%20dc%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%20SELECT%20%3Fbook%20%3Fwho%20WHERE%20%7B%20%3Fbook%20dc%3Acreator%20%3Fwho%20%7D"],
             ["/go{?uri}", "/go?uri=http%3A%2F%2Fexample.org%2F%3Furi%3Dhttp%253A%252F%252Fexample.org%252F"],
             ["/service{?word}", "/service?word=dr%C3%BCcken"],
-            ["/lookup{?Stra%C3%9Fe}", "/lookup?Stra%25C3%259Fe=Gr%C3%BCner%20Weg"],
+            ["/lookup{?Stra%C3%9Fe}", "/lookup?Stra%C3%9Fe=Gr%C3%BCner%20Weg"],
             ["{random}" , "%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF"],
             ["{?assoc_special_chars*}", "?%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95=%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF"]
         ]
@@ -67,21 +57,8 @@
         },
         "testcases":[
 
-            [ "{/id*}" , ["/person/albums","/albums/person"] ],
-            [ "{/id*}{?fields,token}" , [ 
-            	"/person/albums?fields=id,name,picture&token=12345",
-            	"/person/albums?fields=id,picture,name&token=12345",
-            	"/person/albums?fields=picture,name,id&token=12345",
-            	"/person/albums?fields=picture,id,name&token=12345",
-            	"/person/albums?fields=name,picture,id&token=12345",
-            	"/person/albums?fields=name,id,picture&token=12345",
-            	"/albums/person?fields=id,name,picture&token=12345",
-            	"/albums/person?fields=id,picture,name&token=12345",
-            	"/albums/person?fields=picture,name,id&token=12345",
-            	"/albums/person?fields=picture,id,name&token=12345",
-            	"/albums/person?fields=name,picture,id&token=12345",
-            	"/albums/person?fields=name,id,picture&token=12345"]
-            	]
+            [ "{/id*}" , "/person/albums" ],
+            [ "{/id*}{?fields,token}" , "/person/albums?fields=id,name,picture&token=12345" ]
         ]
     },
     "Additional Examples 3: Empty Variables":{
@@ -113,6 +90,90 @@
             [ "{1337}", "leet,as,it,can,be"],
             [ "{?1337*}", "?1337=leet&1337=as&1337=it&1337=can&1337=be"],
             [ "{?german*}", [ "?11=elf&12=zw%C3%B6lf", "?12=zw%C3%B6lf&11=elf"] ]
+        ]
+    },
+    "Additional Examples 5: Explode Combinations":{
+        "variables" : {
+            "id" : "admin",
+            "token" : "12345",
+            "tab" : "overview",
+            "keys" : {
+                "key1": "val1",
+                "key2": "val2"
+            }
+        },
+        "testcases":[
+            [ "{?id,token,keys*}", [
+                "?id=admin&token=12345&key1=val1&key2=val2",
+                "?id=admin&token=12345&key2=val2&key1=val1"]
+            ],
+            [ "{/id}{?token,keys*}", [
+                "/admin?token=12345&key1=val1&key2=val2",
+                "/admin?token=12345&key2=val2&key1=val1"]
+            ],
+            [ "{?id,token}{&keys*}", [
+                "?id=admin&token=12345&key1=val1&key2=val2",
+                "?id=admin&token=12345&key2=val2&key1=val1"]
+            ],
+            [ "/user{/id}{?token,tab}{&keys*}", [
+                "/user/admin?token=12345&tab=overview&key1=val1&key2=val2",
+                "/user/admin?token=12345&tab=overview&key2=val2&key1=val1"]
+            ]
+        ]
+    },
+    "Additional Examples 6: Reserved Expansion":{
+        "variables" : {
+            "id" : "admin%2F",
+            "not_pct" : "%foo",
+            "list" : ["red%25", "%2Fgreen", "blue "],
+            "keys" : {
+                "key1": "val1%2F",
+                "key2": "val2%2F"
+            }
+        },
+        "testcases": [
+			["{+id}", "admin%2F"],
+			["{#id}", "#admin%2F"],
+			["{id}", "admin%252F"],
+			["{+not_pct}", "%25foo"],
+			["{#not_pct}", "#%25foo"],
+			["{not_pct}", "%25foo"],
+			["{+list}", "red%25,%2Fgreen,blue%20"],
+			["{#list}", "#red%25,%2Fgreen,blue%20"],
+			["{list}", "red%2525,%252Fgreen,blue%20"],
+			["{+keys}", "key1,val1%2F,key2,val2%2F"],
+			["{#keys}", "#key1,val1%2F,key2,val2%2F"],
+			["{keys}", "key1,val1%252F,key2,val2%252F"]
+        ]
+    },
+    "Additional Examples 7: Prefix Modifiers with Multibyte Characters":{
+        "level": 4,
+        "variables" : {
+            "var" : "value",
+            "greek" : "αβγδε",
+            "currency" : "€uro",
+            "clef" : "𝄞stave"
+        },
+        "testcases": [
+            [ "{greek:1}", "%CE%B1" ],
+            [ "{greek:2}", "%CE%B1%CE%B2" ],
+            [ "{+greek:2}", "%CE%B1%CE%B2" ],
+            [ "{greek:30}", "%CE%B1%CE%B2%CE%B3%CE%B4%CE%B5" ],
+            [ "{currency:1}", "%E2%82%AC" ],
+            [ "{?currency:1}", "?currency=%E2%82%AC" ],
+            [ "{clef:1}", "%F0%9D%84%9E" ],
+            [ "{var:9999}", "value" ]
+        ]
+    },
+    "Additional Examples 8: Literal Encoding":{
+        "level": 1,
+        "variables" : {
+            "var" : "value"
+        },
+        "testcases": [
+            [ "café/{var}", "caf%C3%A9/value" ],
+            [ "x%20y/{var}", "x%20y/value" ],
+            [ "x%20y{var}z%20w", "x%20yvaluez%20w" ]
         ]
     }
 }

--- a/tests/fixtures/negative-tests.json
+++ b/tests/fixtures/negative-tests.json
@@ -50,7 +50,14 @@
             [ "/{default-graph-uri}", false ],
             [ "/sparql{?query,default-graph-uri}", false ],
             [ "/sparql{?query){&default-graph-uri*}", false ],
-            [ "/resolution{?x, y}" , false ]
+            [ "/resolution{?x, y}", false ],
+            [ "{var:0}", false ],
+            [ "{var:01}", false ],
+            [ "{var:10000}", false ],
+            [ "{var:}", false ],
+            [ "{x.}", false ],
+            [ "{x..y}", false ],
+            [ "{%2x}", false ]
 
         ]
     }

--- a/tests/fixtures/spec-examples-by-section.json
+++ b/tests/fixtures/spec-examples-by-section.json
@@ -1,4 +1,13 @@
 {
+  "2.1 Literals" :
+  {
+    "variables": {
+       "count"      : ["one", "two", "three"]
+     },
+     "testcases" : [
+        ["'{count}'", "'one,two,three'"]
+      ]
+  },
   "3.2.1 Variable Expansion" :
   {
     "variables": {
@@ -17,7 +26,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -50,7 +59,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -104,7 +113,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -161,7 +170,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -203,7 +212,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
     },
     "testcases" : [
@@ -255,7 +264,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -307,7 +316,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -358,7 +367,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -406,7 +415,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [

--- a/tests/fixtures/spec-examples.json
+++ b/tests/fixtures/spec-examples.json
@@ -8,6 +8,7 @@
      },
      "testcases" : [
         ["{var}", "value"],
+        ["'{var}'", "'value'"],
         ["{hello}", "Hello%20World%21"]
      ]
   },


### PR DESCRIPTION
`{greek:1}` with `greek := "αβγδε"` expands to `%CE` — a truncated UTF-8 sequence. The prefix modifier uses byte-based `substr()` in `Operator\Abstraction`, so `{var:n}`, `{+var:n}`, `{#var:n}`, `{/var:n}` and `{.var:n}` all split multi-octet characters; RFC 6570 §2.4.1 counts max-length "in characters, not octets". `Named` already uses `mb_substr()` (`{?greek:1}` is correct) — this applies the same to the other operators.

Two related issues in the same encoding layer: reserved/fragment expansion re-encoded existing pct-encoded triplets (`{+id}` with `id := "admin%2F"` gave `admin%252F`; §3.2.3 passes triplets through), and a pct-encoded triplet in a variable name was re-encoded (`/lookup{?Stra%C3%9Fe}` emitted `Stra%25C3%259Fe=...`; §2.3 allows pct-encoded in varname). A bare `%` that is not a valid triplet is still encoded to `%25`, and simple expansion still double-encodes — those cases were already correct and keep their assertions. Non-ASCII literal text is now pct-encoded on expansion (`café/{var}` → `caf%C3%A9/value`, §3.1), and `extract()` accepts both forms; ASCII literals are deliberately left as-is, since encoding them would change templates like `{var}|{hello}` used throughout the existing suite.

`tests/fixtures/*.json` refreshed from uri-templates/uritemplate-test HEAD — the vendored snapshot predates its "Additional Examples 5-8" groups, which cover exactly these cases. The library now passes all 234 positive corpus cases (was 221). Note `negative-tests.json` is vendored but not loaded by the suite; left as-is, since template-validation strictness is a separate question. Behaviour on cases the corpus doesn't pin (e.g. a prefix cutting into a triplet, `{+id:6}` → `admin%25`) was checked against std-uritemplate (Go) and python-hyper/uritemplate, which agree.
